### PR TITLE
check if menus folder exists, before trying to create it

### DIFF
--- a/daiquiri_navigation.php
+++ b/daiquiri_navigation.php
@@ -4,8 +4,9 @@ add_action('wp_update_nav_menu', 'daiquiri_update_nav_menu');
 
 function daiquiri_update_nav_menu() {
     // check if the wp-content/menus directory exists
-    mkdir(WP_CONTENT_DIR . '/menus/', 0755);
-
+    if (!is_dir(WP_CONTENT_DIR . '/menus/')) {
+        mkdir(WP_CONTENT_DIR . '/menus/', 0755);
+    }
     // loop over menus and save the html in the wp-content/menus directory
     foreach (get_terms( 'nav_menu') as $menu) {
         $html = wp_nav_menu(array(


### PR DESCRIPTION
The Wordpress page is showing error messages, when trying to save a menu, when the menus folder is already existing. This PR fixes this message, by first checking whether the path already exists.